### PR TITLE
Support URI to swagger schema with custom url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ ARG GO_VERSION=1.18
 # First stage: build the executable.
 FROM golang:${GO_VERSION}-alpine AS builder
 
+ARG MAIN_REPO=https://dl-cdn.alpinelinux.org/alpine/v3.10/main/
+ARG COMMUNITY_REPO=https://dl-cdn.alpinelinux.org/alpine/v3.10/community/
+
 # Create the user and group files that will be used in the running container to
 # run the process as an unprivileged user.
 RUN mkdir /user && \
     echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd && \
     echo 'nobody:x:65534:' > /user/group && \
-    echo 'https://art.lmru.tech/apk-remote-alpine/v3.10/main' > /etc/apk/repositories && \
-    echo 'https://art.lmru.tech/apk-remote-alpine/v3.10/community' >> /etc/apk/repositories
+    echo $MAIN_REPO > /etc/apk/repositories && \ 
+    echo $COMMUNITY_REPO >> /etc/apk/repositories 
 
 # Install the Certificate-Authority certificates for the app to be able to make
 # calls to HTTPS endpoints.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,8 @@ node('dockerhost') {
 
     env.DOCKER_IMAGE = 'docker-devops.art.lmru.tech/bricks/ingress-autoswagger'
     env.DOCKER_REGISTRY_CREDS = 'lm-sa-devops'
-
+    env.APK_MAIN_REPO = 'https://art.lmru.tech/apk-remote-alpine/v3.10/main'
+    env.APK_COMMUNITY_REPO = 'https://dl-cdn.alpinelinux.org/alpine/v3.10/community/'
     timestamps {
         ansiColor('xterm') {
             stage('Checkout') {
@@ -49,7 +50,11 @@ def image_build_and_push() {
     } else {
         TAG = BRANCH_NAME
     }
-    def image = docker.build("${env.DOCKER_IMAGE}:${TAG}", ".")
+    def image = docker.build("${env.DOCKER_IMAGE}:${TAG}", 
+                "--build-arg MAIN_REPO=${APK_MAIN_REPO}",
+                "--build-arg COMMUNITY_REPO=${APK_COMMUNITY_REPO}",
+                "."
+    )
     try {
         docker.withRegistry("https://$DOCKER_IMAGE", "$DOCKER_REGISTRY_CREDS") {
             image.push(TAG)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ node('dockerhost') {
     env.DOCKER_IMAGE = 'docker-devops.art.lmru.tech/bricks/ingress-autoswagger'
     env.DOCKER_REGISTRY_CREDS = 'lm-sa-devops'
     env.APK_MAIN_REPO = 'https://art.lmru.tech/apk-remote-alpine/v3.10/main'
-    env.APK_COMMUNITY_REPO = 'https://dl-cdn.alpinelinux.org/alpine/v3.10/community/'
+    env.APK_COMMUNITY_REPO = 'https://art.lmru.tech/apk-remote-alpine/v3.10/community'
     timestamps {
         ansiColor('xterm') {
             stage('Checkout') {

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Start Ingress Autoswagger in the root `/` path, specify names of services and yo
 
 ## How it works
 Assume, you have three microservices `cart`, `delivery`, and `payment` deployed on the same host.
-To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs` or a link specified in the OPENAPI_PATHS environment variable.
+To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs` or a link specified in the OPENAPI_URLS environment variable.
 For example:
 
 * `/cart/v3/api-docs`
@@ -29,7 +29,7 @@ The application finds the right version of the specification for each service an
 * Can be `"yml"` for url: service/v3/api-docs.yml
 * Must be passed through `discoveringApidocsExtension: "yml"` in values.yaml 
 * **REFRESH_CRON** *`default: @every 1m`* schedule for check liveness of applications
-* **OPENAPI_PATHS** *`Optional, default: null`* array includes all possible paths to the [Open API JSON](https://swagger.io/specification/) specifications. 
+* **OPENAPI_URLS** *`Optional, default: null`* array includes all possible full paths to the [Open API JSON](https://swagger.io/specification/) specifications. 
 This value will rewrite standard URL pattern /{version}/api-docs and will ignore VERSIONS and APIDOCS_EXTENSION values. 
 
 ## Usage
@@ -58,13 +58,13 @@ docker run -it -e SERVICES="[\"plaster-calculator\",\"product-binder\"]" -e VERS
 ### Without docker
 
 ```bash
-SERVICES="[\"plaster-calculator\",\"product-binder\"]" VERSIONS="[\"v2\",\"v3\"]" go run ingress-autoswagger.go 
+OPENAPI_URLS="[\"http://plaster-calculator/v2/swagger.json\",\"https://product-binder/api-json\"]" go run ingress-autoswagger.go
 ```
 
-#### OR
+#### OR (deprecated)
 
 ```bash
-SERVICES="[\"plaster-calculator\",\"product-binder\"]" OPENAPI_PATHS="[\"api-json\",\"v2/swagger.json\",\"v2/swagger.yaml\"]" go run ingress-autoswagger.go
+SERVICES="[\"plaster-calculator\",\"product-binder\"]" VERSIONS="[\"v2\",\"v3\"]" go run ingress-autoswagger.go 
 ```
 
 After run you can open http://localhost:3000 in browser.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ Start Ingress Autoswagger in the root `/` path, specify names of services and yo
 
 ## How it works
 Assume, you have three microservices `cart`, `delivery`, and `payment` deployed on the same host.
-To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs`. 
+To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs` or a link specified in the OPENAPI_PATHS environment variable. For example: 
 For example:
 
 * `/cart/v3/api-docs`
 * `/delivery/v3/api-docs`
 * `/payment/v3/api-docs`
+* `/binder/api-json`
+* `/binder/v2/swagger.json`
 
 Then, run this application with environment variable `SERVICES=["cart", "delivery", "payment"]"` and expose to `/`.
 The application finds the right version of the specification for each service and periodically checks the liveness of the applications.
@@ -27,7 +29,8 @@ The application finds the right version of the specification for each service an
 * Can be `"yml"` for url: service/v3/api-docs.yml
 * Must be passed through `discoveringApidocsExtension: "yml"` in values.yaml 
 * **REFRESH_CRON** *`default: @every 1m`* schedule for check liveness of applications
-* **SWAGGER_JSON_URI** can be null, path to swagger schema 
+* **OPENAPI_PATHS** *`Optional, default: null`* array includes all possible paths to the [Open API JSON](https://swagger.io/specification/) specifications. 
+This value will rewrite standard URL pattern /{version}/api-docs and will ignore VERSIONS and APIDOCS_EXTENSION values. 
 
 ## Usage
 
@@ -49,7 +52,7 @@ docker build -t ingress-autoswagger .
 ### With docker (stored inside LMRU, needs to be built for external setups)
 
 ```bash
-docker run -it -e SERVICES="[\"plaster-calculator\",\"product-binder\"]" -e VERSIONS="[\"v2\",\"v3\"]" ingress-autoswagger:latest
+docker run -it -e SERVICES="[\"plaster-calculator\",\"product-binder\"]" -e VERSIONS="[\"v2\",\"v3\"]" docker.art.lmru.tech/bricks/ingress-autoswagger:latest
 ```
 
 ### Without docker
@@ -61,7 +64,7 @@ SERVICES="[\"plaster-calculator\",\"product-binder\"]" VERSIONS="[\"v2\",\"v3\"]
 #### OR
 
 ```bash
-SERVICES="[\"plaster-calculator\",\"product-binder\"]" SWAGGER_JSON_URI="[\"api-json\",\"v2/swagger.json\",\"v2/swagger.yaml\"]" go run ingress-autoswagger.go
+SERVICES="[\"plaster-calculator\",\"product-binder\"]" OPENAPI_PATHS="[\"api-json\",\"v2/swagger.json\",\"v2/swagger.yaml\"]" go run ingress-autoswagger.go
 ```
 
 After run you can open http://localhost:3000 in browser.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Start Ingress Autoswagger in the root `/` path, specify names of services and yo
 
 ## How it works
 Assume, you have three microservices `cart`, `delivery`, and `payment` deployed on the same host.
-To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs` or a link specified in the OPENAPI_PATHS environment variable. For example: 
+To make this work, each application should expose [Open API JSON](https://swagger.io/specification/) on `/{version}/api-docs` or a link specified in the OPENAPI_PATHS environment variable.
 For example:
 
 * `/cart/v3/api-docs`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The application finds the right version of the specification for each service an
 * Can be `"yml"` for url: service/v3/api-docs.yml
 * Must be passed through `discoveringApidocsExtension: "yml"` in values.yaml 
 * **REFRESH_CRON** *`default: @every 1m`* schedule for check liveness of applications
+* **SWAGGER_JSON_URI** can be null, path to swagger schema 
 
 ## Usage
 
@@ -39,16 +40,28 @@ helm upgrade --install --namespace \
  $namespace $release-name lmru/ingress-autoswagger
 ```
 
+### Build docker
+
+```bash
+docker build -t ingress-autoswagger .
+```
+
 ### With docker (stored inside LMRU, needs to be built for external setups)
 
 ```bash
-docker run -it -e SERVICES="[\"plaster-calculator\",\"product-binder\"]" -e VERSIONS="[\"v2\",\"v3\"]" docker-devops.art.lmru.tech/bricks/ingress-autoswagger:4.0.0
+docker run -it -e SERVICES="[\"plaster-calculator\",\"product-binder\"]" -e VERSIONS="[\"v2\",\"v3\"]" ingress-autoswagger:latest
 ```
 
 ### Without docker
 
 ```bash
 SERVICES="[\"plaster-calculator\",\"product-binder\"]" VERSIONS="[\"v2\",\"v3\"]" go run ingress-autoswagger.go 
+```
+
+#### OR
+
+```bash
+SERVICES="[\"plaster-calculator\",\"product-binder\"]" SWAGGER_JSON_URI="[\"api-json\",\"v2/swagger.json\",\"v2/swagger.yaml\"]" go run ingress-autoswagger.go
 ```
 
 After run you can open http://localhost:3000 in browser.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Chart for ingress-autoswagger – provides swagger-ui for all specifed in SERVICES env endpoints
 name: ingress-autoswagger
-version: 4.0.1
+version: 4.1.0

--- a/helm/templates/autoswagger.yaml
+++ b/helm/templates/autoswagger.yaml
@@ -85,6 +85,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
     - host: {{ .Values.hostname }}

--- a/helm/templates/autoswagger.yaml
+++ b/helm/templates/autoswagger.yaml
@@ -36,6 +36,10 @@ spec:
             - name: VERSIONS
               value: {{ .Values.discoveringVersion | toJson | quote }}
             {{ end }}
+            {{ if .Values.swaggerJsonUri }}
+            - name: SWAGGER_JSON_URI
+              value: {{ .Values.swaggerJsonUri | toJson | quote }}
+            {{ end }}
             - name: APIDOCS_EXTENSION
               value: {{ .Values.discoveringApidocsExtension }}
           livenessProbe:

--- a/helm/templates/autoswagger.yaml
+++ b/helm/templates/autoswagger.yaml
@@ -36,9 +36,9 @@ spec:
             - name: VERSIONS
               value: {{ .Values.discoveringVersion | toJson | quote }}
             {{ end }}
-            {{ if .Values.openApiPaths }}
-            - name: OPENAPI_PATHS
-              value: {{ .Values.openApiPaths | toJson | quote }}
+            {{ if .Values.openApiUrls }}
+            - name: OPENAPI_URLS
+              value: {{ .Values.openApiUrls | toJson | quote }}
             {{ end }}
             - name: APIDOCS_EXTENSION
               value: {{ .Values.discoveringApidocsExtension }}

--- a/helm/templates/autoswagger.yaml
+++ b/helm/templates/autoswagger.yaml
@@ -37,8 +37,8 @@ spec:
               value: {{ .Values.discoveringVersion | toJson | quote }}
             {{ end }}
             {{ if .Values.swaggerJsonUri }}
-            - name: SWAGGER_JSON_URI
-              value: {{ .Values.swaggerJsonUri | toJson | quote }}
+            - name: OPENAPI_PATHS
+              value: {{ .Values.openApiPaths | toJson | quote }}
             {{ end }}
             - name: APIDOCS_EXTENSION
               value: {{ .Values.discoveringApidocsExtension }}

--- a/helm/templates/autoswagger.yaml
+++ b/helm/templates/autoswagger.yaml
@@ -36,7 +36,7 @@ spec:
             - name: VERSIONS
               value: {{ .Values.discoveringVersion | toJson | quote }}
             {{ end }}
-            {{ if .Values.swaggerJsonUri }}
+            {{ if .Values.openApiPaths }}
             - name: OPENAPI_PATHS
               value: {{ .Values.openApiPaths | toJson | quote }}
             {{ end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,5 @@
 enabled: true
-version: "4.0.1"
+version: "4.1.0"
 imageName: "docker.art.lmru.tech/bricks/ingress-autoswagger"
 refreshCron: "@every 1m"
 ingressPath: "/"

--- a/ingress-autoswagger.go
+++ b/ingress-autoswagger.go
@@ -45,7 +45,7 @@ func main() {
 	//set versions
 	versionsEnv, versionsEnvExists := os.LookupEnv("VERSIONS")
 	apidocsExtensionEnv, apidocsExtensionEnvExists := os.LookupEnv("APIDOCS_EXTENSION")
-	swaggerJsonUriEnv, swaggerJsonUriEnvExists := os.LookupEnv("SWAGGER_JSON_URI")
+	openApiPathsEnv, openApiPathsEnvExists := os.LookupEnv("OPENAPI_PATHS")
 
 	if versionsEnvExists {
 		versions = mapValues(strings.Split(versionsEnv[1:len(versionsEnv)-1], ","), func(s string) string {
@@ -60,16 +60,21 @@ func main() {
 		apidocsExtension = "." + apidocsExtensionEnv
 	}
 
-	if (swaggerJsonUriEnvExists) {
-		swaggerJsons = mapValues(strings.Split(swaggerJsonUriEnv[1:len(swaggerJsonUriEnv)-1], ","), func(s string) string {
+	if !openApiPathsEnvExists {
+		log.Println("WARNING: The VERSION and APIDOCS _EXTENSION environment variables are deprecated, ", 
+			"it is recommended to use the OPENAPI_PATHS variable instead")
+	}
+
+	if openApiPathsEnvExists {
+		swaggerJsons = mapValues(strings.Split(openApiPathsEnv[1:len(openApiPathsEnv)-1], ","), func(s string) string {
 			return s[1 : len(s)-1]
 		})
 	}
 
 	log.Println("Server started on 3000 port!")
 	log.Println("Services:", services)
-	if (swaggerJsonUriEnvExists) {
-		log.Println("Swagger Json URI:", swaggerJsons)
+	if openApiPathsEnvExists {
+		log.Println("OpenApi Paths URI:", swaggerJsons)
 	}
 	log.Println("Discovering versions:", versions, " with extension", apidocsExtensionEnv)
 

--- a/ingress-autoswagger.go
+++ b/ingress-autoswagger.go
@@ -60,22 +60,18 @@ func main() {
 		apidocsExtension = "." + apidocsExtensionEnv
 	}
 
-	if !openApiPathsEnvExists {
-		log.Println("WARNING: The VERSION and APIDOCS _EXTENSION environment variables are deprecated, ", 
-			"it is recommended to use the OPENAPI_PATHS variable instead")
-	}
-
 	if openApiPathsEnvExists {
 		swaggerJsons = mapValues(strings.Split(openApiPathsEnv[1:len(openApiPathsEnv)-1], ","), func(s string) string {
 			return s[1 : len(s)-1]
 		})
+		log.Println("OpenApi Paths URI:", swaggerJsons)
+	} else {
+		log.Println("WARNING: The VERSION and APIDOCS _EXTENSION environment variables are deprecated, ", 
+			"it is recommended to use the OPENAPI_PATHS variable instead")
 	}
 
 	log.Println("Server started on 3000 port!")
 	log.Println("Services:", services)
-	if openApiPathsEnvExists {
-		log.Println("OpenApi Paths URI:", swaggerJsons)
-	}
 	log.Println("Discovering versions:", versions, " with extension", apidocsExtensionEnv)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +94,6 @@ func main() {
 			return
 		}
 	})
-
 
 	http.HandleFunc("/refresh", func(w http.ResponseWriter, r *http.Request) {
 		refreshCache(services)

--- a/ingress-autoswagger.go
+++ b/ingress-autoswagger.go
@@ -90,7 +90,6 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		content, err := json.Marshal(cachedAvailableServices)
 		data := string(content)
-		log.Println("data", data)
 		if err := tpl.Execute(w, data); err != nil {
 			return
 		}

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8">
     <title>Swagger UI</title>
 
-    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.25.0/favicon-32x32.png">
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui.css">
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@4.10.3/favicon-32x32.png">
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@4.10.3/swagger-ui.css">
 
-    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-standalone-preset.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@4.10.3/swagger-ui-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@4.10.3/swagger-ui-bundle.js"></script>
 </head>
 <body>
     <div id="swagger-ui"></div>


### PR DESCRIPTION
1. removed binding to art.lmru in Dockerfile
2. support custom location to swagger schema with maintaining backwards compatibility

Motivation:
Not all services have a v3/api-docs path to the swagger, for example, NestJS uses {apiUrl}-json https://github.com/nestjs/swagger/blob/master/lib/swagger-module.ts#L81

In the future, I propose to get rid of the hardcode of the version, extension and api-docs of the url